### PR TITLE
feat: 45: create new path

### DIFF
--- a/Page2.js
+++ b/Page2.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { View, Text, ActivityIndicator, Button } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView, { Marker, Polyline } from 'react-native-maps';
 import * as Location from 'expo-location';
 import styles from './styles';
 import Constants from 'expo-constants';
@@ -29,8 +29,9 @@ export default function Map() {
   const [nearestBars, setNearestBars] = useState([]);
   const [errorMsg, setErrorMsg] = useState(null);
   const [loading, setLoading] = useState(false);
-
-  // Extracted function to get location and bars
+  const [activePath, setActivePath] = useState([]); // only one path now
+  const [pathActive, setPathActive] = useState(false); 
+  // Get location + bars
   const updateLocationAndBars = useCallback(async () => {
     setLoading(true);
     try {
@@ -44,7 +45,10 @@ export default function Map() {
       const currentLocation = await Location.getCurrentPositionAsync({});
       setLocation(currentLocation.coords);
 
-      const bars = await fetchNearestBars(currentLocation.coords.latitude, currentLocation.coords.longitude);
+      const bars = await fetchNearestBars(
+        currentLocation.coords.latitude,
+        currentLocation.coords.longitude
+      );
       setNearestBars(bars);
     } catch (error) {
       setErrorMsg('Error getting location or bars.');
@@ -53,13 +57,9 @@ export default function Map() {
     setLoading(false);
   }, []);
 
-  // On mount, fetch initial data
+  // On mount
   useEffect(() => {
     updateLocationAndBars();
-
-    // Optional: auto-refresh every 60 seconds
-    // const intervalId = setInterval(updateLocationAndBars, 60000);
-    // return () => clearInterval(intervalId);
   }, [updateLocationAndBars]);
 
   if (errorMsg) {
@@ -90,6 +90,7 @@ export default function Map() {
         }}
         showsUserLocation={true}
       >
+        {/* User marker */}
         <Marker
           coordinate={{
             latitude: location.latitude,
@@ -99,6 +100,7 @@ export default function Map() {
           pinColor="blue"
         />
 
+        {/* Bars */}
         {nearestBars.map((bar) => (
           <Marker
             key={bar.place_id}
@@ -109,16 +111,88 @@ export default function Map() {
             title={bar.name}
             description={bar.vicinity}
             pinColor="orange"
+            onPress={() => {
+              if (!pathActive) return;
+              const newPoint = {
+                latitude: bar.geometry.location.lat,
+                longitude: bar.geometry.location.lng,
+                name: bar.name,
+              };
+              setActivePath([...activePath, newPoint]);
+            }}
           />
         ))}
+
+        {/* Active path */}
+        {activePath.length > 0 && (
+          <Polyline coordinates={activePath} strokeColor="#00AAFF" strokeWidth={3} />
+        )}
       </MapView>
 
+      {/* Buttons */}
       <View style={{ position: 'absolute', top: 40, left: 10, right: 10, alignItems: 'center' }}>
         <Button title="Refresh Location & Bars" onPress={updateLocationAndBars} disabled={loading} />
       </View>
 
+      <View
+        style={{
+          position: 'absolute',
+          top: 80,
+          left: 10,
+          right: 10,
+          alignItems: 'center',
+        }}
+      >
+        <Button
+          title="Start New Path"
+          onPress={() => {
+            setActivePath([]);
+            setPathActive(true);
+          }}
+        />
+      </View>
+
+      <View
+        style={{
+          position: 'absolute',
+          top: 120,
+          left: 10,
+          right: 10,
+          alignItems: 'center',
+        }}
+      >
+        <Button
+          title="Stop Path"
+          onPress={() => {
+            setPathActive(false);
+          }}
+          disabled={!pathActive}
+        />
+      </View>
+
+      <View
+        style={{
+          position: 'absolute',
+          top: 140,
+          left: 10,
+          right: 10,
+          alignItems: 'center',
+        }}
+      >
+        <Button title="Clear Path" onPress={() => setActivePath([])} />
+      </View>
+
       {loading && (
-        <View style={{ position: 'absolute', top: 10, left: 10, backgroundColor: 'white', padding: 8, borderRadius: 4 }}>
+        <View
+          style={{
+            position: 'absolute',
+            top: 10,
+            left: 10,
+            backgroundColor: 'white',
+            padding: 8,
+            borderRadius: 4,
+          }}
+        >
           <Text>Loading...</Text>
         </View>
       )}


### PR DESCRIPTION
These changes make it so that there are 3 additional buttons on the map. 'Start Path' will make it so that any bar marker you click on will extend a path. 'Stop path' will stop the path building and your path remains on the screen. 'Clear Path' will clear the path from the screen.

Closes: #45 